### PR TITLE
Update random functions to add min max

### DIFF
--- a/hl-gen.js
+++ b/hl-gen.js
@@ -65,7 +65,8 @@ const hl = (function () {
     const tokenId = searchParams.get("tid") || Math.floor(100 * Math.random()).toString();
     const walletAddress = searchParams.get("wa") || generateRandomAddress();
     const timestamp = searchParams.get("t") || Date.now().toString();
-    const seed = xmur3(hash + tokenId);
+    const isCurated = searchParams.get("ic") || "0";
+    const seed = isCurated === "1"? xmur3(hash) : xmur3(hash + tokenId);
 
     const hl = {
         tx: {


### PR DESCRIPTION
Update random functions to use min max value.

Proposal by @willdawson 

> **possible proposal:**
get rid of hl.randomNum()
hl.random() takes 0, 1, or two args
hl.random() does what it does today (returns random number [0-1)
hl.random(max) returns number [0-max)
hl.random(min, max) returns number [min-max)
hl.randomInt could also take 1 or 2 arguments, doing the same thing with ints
hl.randomInt(100) -> int [0-100]
hl.randomInt(100, 200) -> int [100-200]

- Add min max to hl.random() if not provided defaults to [0,1)
- Add min max to hl.randomInt(), if not provided defaults to max of 100.