### PR TITLE
Add blockNumber to the API

### DIFF
--- a/hl-gen.js
+++ b/hl-gen.js
@@ -82,6 +82,7 @@ const hl = (function () {
       chainId,
       hash,
       blockHash,
+      blockNumber,
       timestamp,
       walletAddress,
       tokenId,


### PR DESCRIPTION
`blockNumber` was missing from the API, making scripts using it display `undefined`.